### PR TITLE
Fix/scroll on navigate

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,7 +12,11 @@ import Footer from './common/Footer';
 import '../style/styles.scss';
 
 const history = createHistory();
-history.listen(() => {
+history.listen((location, action) => {
+  //Hack to remove extra focus from header-link when clicking back
+  if (action === 'POP') {
+    document.activeElement.blur();
+  }
   window.scrollTo(0,0);
 });
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
-import { Route, Switch, BrowserRouter as Router } from 'react-router-dom';
+import { Route, Switch, Router } from 'react-router-dom';
+import createHistory from 'history/createBrowserHistory';
 
 import Header from './common/Header';
 import Home from './home/Home';
@@ -10,11 +11,16 @@ import Footer from './common/Footer';
 
 import '../style/styles.scss';
 
+const history = createHistory();
+history.listen(() => {
+  window.scrollTo(0,0);
+});
+
 class App extends Component {
 
   render () {
     return (
-      <Router>
+      <Router history={history}>
         <div>
           <Header />
             <Switch>


### PR DESCRIPTION
Added a history-handler to take care of scroll to top on navigation, and to remove focus when going back in browser to fix the double highlight issue